### PR TITLE
print versions in check mode for black, isort and flynt

### DIFF
--- a/.github/workflows/black-command.yml
+++ b/.github/workflows/black-command.yml
@@ -23,7 +23,9 @@ jobs:
       # Execute black in check mode
       - name: Black
         id: black
-        run: echo ::set-output name=format::$(black --check --quiet . || echo "true")
+        run: |
+          black --version
+          echo ::set-output name=format::$(black --check --quiet . || echo "true")
 
       # Execute black and commit the change to the PR branch
       - name: Commit to the PR branch

--- a/.github/workflows/flynt-command.yml
+++ b/.github/workflows/flynt-command.yml
@@ -23,7 +23,9 @@ jobs:
       # Execute flynt in check mode
       - name: flynt
         id: flynt
-        run: echo ::set-output name=format::$(flynt --fail-on-change -n yt/ --exclude yt/extern || echo "true")
+        run: |
+          flynt --version
+          echo ::set-output name=format::$(flynt --fail-on-change -n yt/ --exclude yt/extern || echo "true")
 
       # Execute flynt and commit the change to the PR branch
       - name: Commit to the PR branch

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -18,22 +18,30 @@ jobs:
 
       # Install black and isort
       - name: Install black, isort and flynt
-        run: pip install black isort flynt
+        run: |
+          python --version 
+          pip install black isort flynt
 
       # Execute black in check mode
       - name: Black
         id: black
-        run: echo ::set-output name=format::$(black --check --quiet . || echo "true")
+        run: |
+          black --version
+          echo ::set-output name=format::$(black --check --quiet . || echo "true")
 
       # Execute isort in check mode
       - name: isort
         id: isort
-        run: echo ::set-output name=format::$(isort --check --quiet . || echo "true")
+        run: |
+          isort --version
+          echo ::set-output name=format::$(isort --check --quiet . || echo "true")
 
       # Execute isort in check mode
       - name: flynt
         id: flynt
-        run: echo ::set-output name=format::$(flynt --fail-on-change --dry-run yt/ --exclude yt/extern || echo "true")
+        run: |
+          flynt --version
+          echo ::set-output name=format::$(flynt --fail-on-change --dry-run yt/ --exclude yt/extern || echo "true")
 
       # Execute black and isort and commit the change to the PR branch
       - name: Commit to the PR branch

--- a/.github/workflows/isort-command.yml
+++ b/.github/workflows/isort-command.yml
@@ -23,7 +23,10 @@ jobs:
       # Execute isort in check mode
       - name: isort
         id: isort
-        run: echo ::set-output name=format::$(isort --check --quiet . || echo "true")
+        run: |
+          python --version
+          isort --version
+          echo ::set-output name=format::$(isort --check --quiet . || echo "true")
 
       # Execute isort and commit the change to the PR branch
       - name: Commit to the PR branch


### PR DESCRIPTION
Seems like sometimes results from slash commands don't satisfy the checks on Travis, likely due to different versions in the checkers. This adds a `<checker> --version` step to all check so as to make those conflicts easier to debug.
It'd be good to simply force the sync by installing the version pinned in yt/tests/lint_requirement though I'm not sure how to do this within a separate repo.