### PR TITLE
Try to make isort the right version

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install black and isort
       - name: Install black, isort and flynt
-        run: pip install black isort flynt
+        run: pip install -U black "isort>=5.1" flynt
 
       # Execute black in check mode
       - name: Black

--- a/.github/workflows/isort-command.yml
+++ b/.github/workflows/isort-command.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install isort
       - name: Install isort
-        run: pip install isort
+        run: pip install -U "isort>=5.1"
 
       # Execute isort in check mode
       - name: isort


### PR DESCRIPTION
What I was finding was that `pylint` had a specific version of isort pinned.  This gets around that by requiring a higher version.  Since we don't call pylint explicitly, this should be OK.
